### PR TITLE
Fix Verilog reset assignments to use non-blocking assignments.

### DIFF
--- a/rust/hwl_language/src/back/lower_verilog.rs
+++ b/rust/hwl_language/src/back/lower_verilog.rs
@@ -739,7 +739,7 @@ fn lower_module_statements(
                             f,
                         };
 
-                        // TODO should resets use blocking or non-blocking assignments?
+                        // Resets use non-blocking assignments to match other register updates
                         for reset in resets {
                             let &(reg, ref value) = &reset.inner;
 
@@ -750,7 +750,7 @@ fn lower_module_statements(
                             };
 
                             let value = unwrap_zero_width(ctx_reset.lower_expression(reset.span, value)?);
-                            swriteln!(ctx_reset.f, "{indent_inner}{reg_name_raw} = {value};");
+                            swriteln!(ctx_reset.f, "{indent_inner}{reg_name_raw} <= {value};");
                         }
 
                         swriteln!(f, "{I}{I}end else begin");


### PR DESCRIPTION
Register reset assignments in clocked blocks were incorrectly using
blocking assignments (=) instead of non-blocking assignments (<=).
This caused Verilator to error with BLKANDNBLK when a register had
both blocking assignments in the reset section and non-blocking
assignments in the normal logic.

This fix changes reset assignments to use non-blocking assignments,
matching the behavior of all other register updates in sequential
blocks and following proper Verilog coding practices.

Fixes test_reg_expression test failure.

https://claude.ai/code/session_01WCoN6BVi3es9ibQJyTeFna